### PR TITLE
Ruby 3.4 support

### DIFF
--- a/lib/mongo_beautiful_logger/mongo_actions.rb
+++ b/lib/mongo_beautiful_logger/mongo_actions.rb
@@ -12,11 +12,11 @@ module MongoActions
   INSERT       = { match: "\"insert\"#{arrow}",      color: GREEN }
   DELETE       = { match: "\"delete\"#{arrow}",      color: RED }
   AGGREGATE    = { match: "\"aggregate\"#{arrow}",   color: MAGENTA }
-  SUCCEEDED    = { match: "succeeded",                   color: GREEN }
-  FAILED       = { match: "failed",                      color: RED }
-  ERROR        = { match: "error",                       color: RED }
+  SUCCEEDED    = { match: "succeeded",               color: GREEN }
+  FAILED       = { match: "failed",                  color: RED }
+  ERROR        = { match: "error",                   color: RED }
   ENDSESSION   = { match: "\"endsessions\"#{arrow}", color: YELLOW }
-  INITIALIZING = { match: "initializing",                color: GREEN }
+  INITIALIZING = { match: "initializing",            color: GREEN }
   ACTIONS      = [ FIND, UPDATE, INSERT, DELETE, AGGREGATE, 
                    SUCCEEDED, FAILED, ERROR, ENDSESSION, INITIALIZING ]
   

--- a/lib/mongo_beautiful_logger/mongo_actions.rb
+++ b/lib/mongo_beautiful_logger/mongo_actions.rb
@@ -3,24 +3,27 @@ require "mongo_beautiful_logger/colors"
 module MongoActions
   include Colors
 
+  # https://bugs.ruby-lang.org/issues/20433
+  arrow = (RUBY_VERSION >= '3.4') ? ' =>' : '=>'
+
   # substring matches and the corresponding colors for mongodb actions
-  FIND         = { match: "\"find\"=>",        color: BLUE }
-  UPDATE       = { match: "\"update\"=>",      color: YELLOW }
-  INSERT       = { match: "\"insert\"=>",      color: GREEN }
-  DELETE       = { match: "\"delete\"=>",      color: RED }
-  AGGREGATE    = { match: "\"aggregate\"=>",   color: MAGENTA }
-  SUCCEEDED    = { match: "succeeded",         color: GREEN }
-  FAILED       = { match: "failed",            color: RED }
-  ERROR        = { match: "error",             color: RED }
-  ENDSESSION   = { match: "\"endsessions\"=>", color: YELLOW }
-  INITIALIZING = { match: "initializing",      color: GREEN }
+  FIND         = { match: "\"find\"#{arrow}",        color: BLUE }
+  UPDATE       = { match: "\"update\"#{arrow}",      color: YELLOW }
+  INSERT       = { match: "\"insert\"#{arrow}",      color: GREEN }
+  DELETE       = { match: "\"delete\"#{arrow}",      color: RED }
+  AGGREGATE    = { match: "\"aggregate\"#{arrow}",   color: MAGENTA }
+  SUCCEEDED    = { match: "succeeded",                   color: GREEN }
+  FAILED       = { match: "failed",                      color: RED }
+  ERROR        = { match: "error",                       color: RED }
+  ENDSESSION   = { match: "\"endsessions\"#{arrow}", color: YELLOW }
+  INITIALIZING = { match: "initializing",                color: GREEN }
   ACTIONS      = [ FIND, UPDATE, INSERT, DELETE, AGGREGATE, 
                    SUCCEEDED, FAILED, ERROR, ENDSESSION, INITIALIZING ]
   
   # substring matches for unnecessary log messages that will be filtered out
   UNNECESSARY  = ["opology", "server description"]
 
-  # regex for for the log prefix that will be filtered out
+  # regex for the log prefix that will be filtered out
   # matches: +| localhost:27017 | app_test.update | STARTED |+
   # note: +| STARTED |+ and +| SUCCEEDED |+ will be filtered due to redundancy,
   # but +| FAILED |+ and others will not

--- a/mongo_beautiful_logger.gemspec
+++ b/mongo_beautiful_logger.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.7"
+  spec.add_development_dependency "rake", "~> 13.3"
 end


### PR DESCRIPTION
## Purpose

Add support for ruby 3.4.x. The problem is that ruby 3.4 changed the behavior of `Hash#inspect` adding spaces between `=>`

References

https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/
https://rubyreferences.github.io/rubychanges/3.4.html#inspect-rendering-have-been-changed
http://bugs.ruby-lang.org/issues/20433

- Development dependencies updated

## See

<img width="585" height="164" alt="image" src="https://github.com/user-attachments/assets/c8673978-823d-4ce6-b687-21ac72028a95" />
